### PR TITLE
Kyolee3

### DIFF
--- a/srcs/execute/child_pipe.c
+++ b/srcs/execute/child_pipe.c
@@ -45,25 +45,19 @@ void	child_pipe(t_node **cur_process, t_func_type builtin[],
 	}
 	*cur_process = (*cur_process)->right;
 }
-/*
-void	wait_for_remain_child_processes(int cnt)
+
+void	wait_for_remain_child_processes(void)
 {
 	int	status;
-	int	idx;
 
-	idx = 0;
-	while (idx < cnt)
+	while (1)
 	{
-		if (waitpid(-1, &status, 0) < 0)
-		{
-			if (errno == EINTR)
-				continue;
-			else
-				idx++;
-		}
+		waitpid(-1, &status, 0);
+		if (errno == ECHILD)
+			break ;
 	}
 }
-*/
+
 void	fork_process(t_struct *ds, int cnt, t_func_type builtin[])
 {
 	int		backup_fd;
@@ -82,12 +76,10 @@ void	fork_process(t_struct *ds, int cnt, t_func_type builtin[])
 		child_process(cur_node->left, builtin, backup_fd);
 	else
 	{
+		e_dup2(backup_fd, STDIN_FILENO);
 		status = 0;
 		waitpid(pid, &status, 0);
 		set_or_get_status(get_child_exit_value(status));
-		//wait_for_remain_child_processes(cnt - 1);
-		while (cnt-- > loop)
-			wait(NULL);
-		e_dup2(backup_fd, STDIN_FILENO);
+		wait_for_remain_child_processes();
 	}
 }

--- a/srcs/execute/child_pipe.c
+++ b/srcs/execute/child_pipe.c
@@ -11,7 +11,6 @@ int	get_child_exit_value(int status)
 
 void	child_process(t_node *cur_phrase, t_func_type builtin[], int backup_fd)
 {
-	int	old_stdin;
 	int	redir_errored;
 	int	b_child_process;
 
@@ -19,14 +18,9 @@ void	child_process(t_node *cur_phrase, t_func_type builtin[], int backup_fd)
 	redir_errored = 0;
 	b_child_process = 1;
 	if (cur_phrase->left)
-	{
-		old_stdin = dup(STDIN_FILENO);
 		redir_action(cur_phrase->left, b_child_process, &redir_errored);
-	}
 	if (cur_phrase->right)
 		cmd_action(cur_phrase->right, builtin);
-	if (cur_phrase->left)
-		e_dup2(old_stdin, STDIN_FILENO);
 	exit(set_or_get_status(-1));
 }
 
@@ -51,7 +45,25 @@ void	child_pipe(t_node **cur_process, t_func_type builtin[],
 	}
 	*cur_process = (*cur_process)->right;
 }
+/*
+void	wait_for_remain_child_processes(int cnt)
+{
+	int	status;
+	int	idx;
 
+	idx = 0;
+	while (idx < cnt)
+	{
+		if (waitpid(-1, &status, 0) < 0)
+		{
+			if (errno == EINTR)
+				continue;
+			else
+				idx++;
+		}
+	}
+}
+*/
 void	fork_process(t_struct *ds, int cnt, t_func_type builtin[])
 {
 	int		backup_fd;
@@ -73,6 +85,7 @@ void	fork_process(t_struct *ds, int cnt, t_func_type builtin[])
 		status = 0;
 		waitpid(pid, &status, 0);
 		set_or_get_status(get_child_exit_value(status));
+		//wait_for_remain_child_processes(cnt - 1);
 		while (cnt-- > loop)
 			wait(NULL);
 		e_dup2(backup_fd, STDIN_FILENO);


### PR DESCRIPTION
1. child_pipe.c (child_pipe 내 dup 코드 제거) 
2. child_pipe.c (wait for remain_child_process 함수 추가)  
3. child_pipe.c (fork_process 내 e_dup2(backup_fd) 라인 위치 수정 
   (cat bigfile | echo nnn 오류 때문) 